### PR TITLE
Dev recover

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -34,13 +34,19 @@ const getPageParam = (searchParams: URLSearchParams): number => {
   return page;
 };
 
+const getPageSizeParam = (searchParams: URLSearchParams): number => {
+  const pageSize = parseInt(searchParams.get("page_size") || "5");
+  if (isNaN(pageSize) || pageSize < 1) {
+    throw new Error("Invalid pageSize provided")
+  }
+  return pageSize;
+}
+
 export async function GET(request: NextRequest): Promise<NextResponse> {
   try {
     const { searchParams } = new URL(request.url);
     const page = getPageParam(searchParams);
-    const pageSize = 5;
-
-    // get pagesize from URLSearchParams?
+    const pageSize = getPageSizeParam(searchParams);
 
     const result = getPaginatedTasks(page, pageSize);
     return NextResponse.json(result);

--- a/src/components/task-item/task-item.tsx
+++ b/src/components/task-item/task-item.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { memo, useState } from "react";
 import { Task } from "@/types/task";
 
 interface TaskItemProps {
   task: Task;
 }
 
-export default function TaskItem({ task }: TaskItemProps) {
+export const TaskItem = memo(({ task }: TaskItemProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   return (
@@ -38,4 +38,4 @@ export default function TaskItem({ task }: TaskItemProps) {
       </button>
     </div>
   );
-}
+});

--- a/src/components/task-list/task-list.tsx
+++ b/src/components/task-list/task-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import TaskItem from "../task-item/task-item";
+import { TaskItem } from "../task-item/task-item";
 import TaskErrorBoundary from "../error-handling/task-error-boundary";
 import LoadingState from "./task-list-loading";
 import React from "react";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,3 +3,4 @@
  */
 export const TASKS_KEY = 'TASKS';
 export const PAGE_KEY = 'PAGE'
+export const PAGE_SIZE = 5; 

--- a/src/hooks/use-task-state-manager.ts
+++ b/src/hooks/use-task-state-manager.ts
@@ -3,7 +3,7 @@
 import { FetchTasksResponse, Task, TaskStateManagerProps, TaskStateManagerReturn } from "@/types/task";
 import { useCallback, useEffect, useReducer, useState } from "react";
 import { getSessionStorage, setSessionStorage } from "./utils/session-storage-utils";
-import { TASKS_KEY, PAGE_KEY } from "@/constants";
+import { TASKS_KEY, PAGE_KEY, PAGE_SIZE } from "@/constants";
 
 type Action =
     | { type: 'LOAD_SESSION_STATE'; tasks: Task[], page: number }
@@ -113,7 +113,7 @@ const useTaskStateManager = (initialTasks: Task[], initialPage: number): TaskSta
 
     useEffect((): void => {
         if (shouldFetch) {
-            fetchTasks(state.page, 5); // UI should provide user choice of pagesize
+            fetchTasks(state.page, PAGE_SIZE);
             setShouldFetch(false);
         }
     }, [state.page, shouldFetch, fetchTasks]);

--- a/src/hooks/use-task-state-manager.ts
+++ b/src/hooks/use-task-state-manager.ts
@@ -88,10 +88,10 @@ const useTaskStateManager = (initialTasks: Task[], initialPage: number): TaskSta
     }, []);
 
     // handles it's errors
-    const fetchTasks = useCallback(async (pageNum: number): Promise<void> => {
+    const fetchTasks = useCallback(async (pageNum: number, pageSize: number): Promise<void> => {
         dispatch({ type: 'FETCHING_TASKS_INIT' })
 
-        const response = await fetch(`/api/tasks?page=${pageNum}`);
+        const response = await fetch(`/api/tasks?page=${pageNum}&page_size=${pageSize}`);
         if (response.status === 200) {
             try {
                 const latestTasks: FetchTasksResponse = await response.json();
@@ -113,7 +113,7 @@ const useTaskStateManager = (initialTasks: Task[], initialPage: number): TaskSta
 
     useEffect((): void => {
         if (shouldFetch) {
-            fetchTasks(state.page);
+            fetchTasks(state.page, 5); // UI should provide user choice of pagesize
             setShouldFetch(false);
         }
     }, [state.page, shouldFetch, fetchTasks]);


### PR DESCRIPTION
This commit makes the API look for page_size in the query parameters, and if it's not there it's default 5. The frontend now has a const PAGE_SIZE which could be a env variable, that is sends as the page_size query parameter to the backend. Not a perfect UX experience, but technically the frontend application is now specifying the page size it wants